### PR TITLE
Pin base docker image to use Spark@3.5.3 and Python@3.11

### DIFF
--- a/spark-notebook/Dockerfile
+++ b/spark-notebook/Dockerfile
@@ -15,21 +15,19 @@ RUN apt-get -y install -qq vim netcat-traditional
 USER jovyan
 WORKDIR /home/jovyan
 
-RUN pip install -q --no-cache-dir 'apache-beam[gcp]' && \
-    fix-permissions "${CONDA_DIR}" && \
-    fix-permissions "/home/${NB_USER}"
-
 RUN pip install -q --no-cache-dir \
+	'apache-beam[gcp]' \
 	mysql-connector-python \
 	pyarrow \
 	pandas \
 	pymongo spylon-kernel
 
+RUN fix-permissions "${CONDA_DIR}" && fix-permissions "/home/jovyan"
+
 # Install Scala kernel
 RUN python -m spylon_kernel install --user
 
 # Install Java kernel
-
 WORKDIR /home/jovyan/local
 RUN wget https://github.com/padreati/rapaio-jupyter-kernel/releases/download/1.2.0/rapaio-jupyter-kernel-1.2.0.jar
 RUN java -jar rapaio-jupyter-kernel-1.2.0.jar -i -auto
@@ -38,8 +36,8 @@ RUN sed -i '4i \
     "--add-exports",\
     "java.base/sun.nio.ch=ALL-UNNAMED",' /home/jovyan/.local/share/jupyter/kernels/rapaio-jupyter-kernel/kernel.json
 
-# setup shared directory
+# Setup shared directory
 RUN mkdir /home/jovyan/shared
 
-# start Jupyterlab in home directory
+# Start Jupyterlab in home directory
 WORKDIR /home/jovyan

--- a/spark-notebook/Dockerfile
+++ b/spark-notebook/Dockerfile
@@ -1,51 +1,31 @@
-FROM quay.io/jupyter/pyspark-notebook:java-17.0.12
+FROM quay.io/jupyter/pyspark-notebook@sha256:999213c55c952aa484128cd0297746703323d4fdfa70fbf66c0922937b3ad45b
 
-USER root
-RUN apt-get update
-RUN apt-get -y install vim
+# equivalent to:
+#
+# FROM quay.io/jupyter/pyspark-notebook:spark-3.5.3
+#
+# on Oct 21, 2024
 
-# revert to Spark 3
-WORKDIR /usr/local
-RUN wget https://dlcdn.apache.org/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
-RUN tar -xzf spark-3.5.3-bin-hadoop3.tgz
-RUN rm spark
-RUN ln -s spark-3.5.3-bin-hadoop3 spark
-
-# switch to user
-RUN chown -R jovyan /home/jovyan
-USER jovyan
-WORKDIR /home/jovyan
-
-# install packages
 RUN pip install --no-cache-dir 'apache-beam[gcp]' && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
 RUN pip install --no-cache-dir mysql-connector-python pymongo
 
-RUN pip install --no-cache-dir pyarrow pandas
+USER root
 
-# install kernels
+RUN apt-get update
+RUN apt-get -y install vim
 
-# RUN pip install --upgrade spylon
-# RUN pip install --upgrade spylon-kernel
-# Temporary fixes until spylon/spylon-kernel are updated
-RUN mkdir /home/jovyan/local
-WORKDIR /home/jovyan/local
-RUN git clone https://github.com/vericast/spylon.git spylon
-RUN git clone https://github.com/vericast/spylon-kernel.git spylon-kernel
-WORKDIR /home/jovyan/local/spylon
-RUN git fetch origin pull/57/head:pull_57
-RUN git checkout pull_57
-RUN pip install -e .
-WORKDIR /home/jovyan/local/spylon-kernel
-RUN git fetch origin pull/71/head:pull_71
-RUN git checkout pull_71
-RUN pip install -e .
+RUN pip install --upgrade spylon-kernel
+RUN python -m spylon_kernel install
 
-RUN python -m spylon_kernel install --user
+RUN pip install pyarrow pandas
 
-WORKDIR /home/jovyan/local
+# Install Java Kernel
+RUN chown -R jovyan /home/jovyan
+USER ${NB_UID}
+RUN cd /home/jovyan
 RUN wget https://github.com/padreati/rapaio-jupyter-kernel/releases/download/1.2.0/rapaio-jupyter-kernel-1.2.0.jar
 RUN java -jar rapaio-jupyter-kernel-1.2.0.jar -i -auto
 
@@ -53,9 +33,4 @@ RUN sed -i '4i \
     "--add-exports",\
     "java.base/sun.nio.ch=ALL-UNNAMED",' /home/jovyan/.local/share/jupyter/kernels/rapaio-jupyter-kernel/kernel.json
 
-# setup shared directory
 RUN mkdir /home/jovyan/shared
-
-# start Jupyterlab in home directory
-WORKDIR /home/jovyan
-

--- a/spark-notebook/Dockerfile
+++ b/spark-notebook/Dockerfile
@@ -6,26 +6,31 @@ FROM quay.io/jupyter/pyspark-notebook@sha256:999213c55c952aa484128cd029774670332
 #
 # on Oct 21, 2024
 
-RUN pip install --no-cache-dir 'apache-beam[gcp]' && \
+# Install system-wide packages
+USER root
+RUN apt-get update -qq 
+RUN apt-get -y install -qq vim netcat-traditional
+
+# Install user packages
+USER jovyan
+WORKDIR /home/jovyan
+
+RUN pip install -q --no-cache-dir 'apache-beam[gcp]' && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
-RUN pip install --no-cache-dir mysql-connector-python pymongo
+RUN pip install -q --no-cache-dir \
+	mysql-connector-python \
+	pyarrow \
+	pandas \
+	pymongo spylon-kernel
 
-USER root
+# Install Scala kernel
+RUN python -m spylon_kernel install --user
 
-RUN apt-get update
-RUN apt-get -y install vim
+# Install Java kernel
 
-RUN pip install --upgrade spylon-kernel
-RUN python -m spylon_kernel install
-
-RUN pip install pyarrow pandas
-
-# Install Java Kernel
-RUN chown -R jovyan /home/jovyan
-USER ${NB_UID}
-RUN cd /home/jovyan
+WORKDIR /home/jovyan/local
 RUN wget https://github.com/padreati/rapaio-jupyter-kernel/releases/download/1.2.0/rapaio-jupyter-kernel-1.2.0.jar
 RUN java -jar rapaio-jupyter-kernel-1.2.0.jar -i -auto
 
@@ -33,4 +38,8 @@ RUN sed -i '4i \
     "--add-exports",\
     "java.base/sun.nio.ch=ALL-UNNAMED",' /home/jovyan/.local/share/jupyter/kernels/rapaio-jupyter-kernel/kernel.json
 
+# setup shared directory
 RUN mkdir /home/jovyan/shared
+
+# start Jupyterlab in home directory
+WORKDIR /home/jovyan


### PR DESCRIPTION
`python 3.11` guarantees that the Spylon kernel still works and `spark 3.5.3` is the latest stable version. Using the image digest will ensure that even when the tag `spark-3.5.3` switches to `python 3.11`, we stay at `3.11`.